### PR TITLE
Mapped attribute bugfix

### DIFF
--- a/src/Pitbulk/Saml2/Saml2User.php
+++ b/src/Pitbulk/Saml2/Saml2User.php
@@ -54,10 +54,10 @@ class Saml2User
         if (empty($unmappedAttributes)) {
             return $unmappedAttributes;
         }
-        $samlSettings = Config::get('laravel4-saml2::saml_settings');
+        $attrMapping = Config::get('laravel4-saml2::saml_settings.lavarel.attrMapping');
         $mappedAttributes = [];
-        if (isset($samlSettings['attrMapping'])) {
-            foreach ($samlSettings['attrMapping'] as $mapped => $unmapped) {
+        if (count($attrMapping)) {
+            foreach ($attrMapping as $mapped => $unmapped) {
                 $mappedAttributes[$mapped] = $unmappedAttributes[$unmapped];
             }
         }

--- a/src/Pitbulk/Saml2/Saml2User.php
+++ b/src/Pitbulk/Saml2/Saml2User.php
@@ -58,6 +58,9 @@ class Saml2User
         $mappedAttributes = [];
         if (count($attrMapping)) {
             foreach ($attrMapping as $mapped => $unmapped) {
+                if (is_array($unmappedAttributes[$unmapped]) and count($unmappedAttributes[$unmapped]) == 1) {
+                    $unmappedAttributes[$unmapped] = array_shift($unmappedAttributes[$unmapped]);
+                }
                 $mappedAttributes[$mapped] = $unmappedAttributes[$unmapped];
             }
         }

--- a/src/Pitbulk/Saml2/Saml2User.php
+++ b/src/Pitbulk/Saml2/Saml2User.php
@@ -58,9 +58,6 @@ class Saml2User
         $mappedAttributes = [];
         if (count($attrMapping)) {
             foreach ($attrMapping as $mapped => $unmapped) {
-                if (is_array($unmappedAttributes[$unmapped]) and count($unmappedAttributes[$unmapped]) == 1) {
-                    $unmappedAttributes[$unmapped] = array_shift($unmappedAttributes[$unmapped]);
-                }
                 $mappedAttributes[$mapped] = $unmappedAttributes[$unmapped];
             }
         }


### PR DESCRIPTION
The settings "path" was wrong before, and for better usability of the resulting array I added a function to remove single cell arrays and return their content instead.